### PR TITLE
Frequency message is an int

### DIFF
--- a/jetson_stats_msgs/msg/JetsonStatus.msg
+++ b/jetson_stats_msgs/msg/JetsonStatus.msg
@@ -8,35 +8,7 @@ float32 cpu_temp       # [Celcius]
 float32 gpu_load
 uint32 gpu_freq        # [kHz]
 float32 gpu_temp       # [Celcius]
-float32 cpu1_load
-uint32 cpu1_freq       # [kHz]
-string cpu1_freq_unit
-string cpu1_governor
-float32 cpu2_load
-uint32 cpu2_freq       # [kHz]
-string cpu2_freq_unit
-string cpu2_governor
-float32 cpu3_load
-uint32 cpu3_freq       # [kHz]
-string cpu3_freq_unit
-string cpu3_governor
-float32 cpu4_load
-uint32 cpu4_freq       # [kHz]
-string cpu4_freq_unit
-string cpu4_governor
-float32 cpu5_load
-uint32 cpu5_freq       # [kHz]
-string cpu5_freq_unit
-string cpu5_governor
-float32 cpu6_load
-uint32 cpu6_freq       # [kHz]
-string cpu6_freq_unit
-string cpu6_governor
-float32 cpu7_load
-uint32 cpu7_freq       # [kHz]
-string cpu7_freq_unit
-string cpu7_governor
-float32 cpu8_load
-uint32 cpu8_freq       # [kHz]
-string cpu8_freq_unit
-string cpu8_governor
+float32[] cpu_load
+uint32[] cpu_freq     # [kHz]
+string[] cpu_freq_unit
+string[] cpu_governor

--- a/jetson_stats_msgs/msg/JetsonStatus.msg
+++ b/jetson_stats_msgs/msg/JetsonStatus.msg
@@ -1,10 +1,42 @@
 Header header
-float32 ram_used     # [MB]
-float32 ram_shared   # [MB]
-float32 ram_total    # [MB]
-float32 swap_used    # [MB]
-float32 swap_total   # [MB]
-float32 cpu_temp     # [Celcius]
+float32 ram_used       # [MB]
+float32 ram_shared     # [MB]
+float32 ram_total      # [MB]
+float32 swap_used      # [MB]
+float32 swap_total     # [MB]
+float32 cpu_temp       # [Celcius]
 float32 gpu_load
-uint32 gpu_freq      # [kHz]
-float32 gpu_temp     # [Celcius]
+uint32 gpu_freq        # [kHz]
+float32 gpu_temp       # [Celcius]
+float32 cpu1_load
+uint32 cpu1_freq       # [kHz]
+string cpu1_freq_unit
+string cpu1_governor
+float32 cpu2_load
+uint32 cpu2_freq       # [kHz]
+string cpu2_freq_unit
+string cpu2_governor
+float32 cpu3_load
+uint32 cpu3_freq       # [kHz]
+string cpu3_freq_unit
+string cpu3_governor
+float32 cpu4_load
+uint32 cpu4_freq       # [kHz]
+string cpu4_freq_unit
+string cpu4_governor
+float32 cpu5_load
+uint32 cpu5_freq       # [kHz]
+string cpu5_freq_unit
+string cpu5_governor
+float32 cpu6_load
+uint32 cpu6_freq       # [kHz]
+string cpu6_freq_unit
+string cpu6_governor
+float32 cpu7_load
+uint32 cpu7_freq       # [kHz]
+string cpu7_freq_unit
+string cpu7_governor
+float32 cpu8_load
+uint32 cpu8_freq       # [kHz]
+string cpu8_freq_unit
+string cpu8_governor

--- a/ros_jetson_stats/scripts/jetson_stats.py
+++ b/ros_jetson_stats/scripts/jetson_stats.py
@@ -168,8 +168,43 @@ class ROSJtop:
             jetson_status.gpu_freq = int(self.arr.status[9].values[1].value)
             # GPU temp
             jetson_status.gpu_temp = float(self.arr.status[13].values[4].value.rstrip("C"))
+            # CPU info
+            #for i in range(1, 8)
+            jetson_status.cpu1_load = PERCENT2SHARE * float(self.arr.status[1].values[0].value.rstrip("%"))
+            jetson_status.cpu1_freq = int(self.arr.status[1].values[1].value)
+            jetson_status.cpu1_freq_unit = self.arr.status[1].values[2].value
+            jetson_status.cpu1_governor = self.arr.status[1].values[3].value
+            jetson_status.cpu2_load = PERCENT2SHARE * float(self.arr.status[2].values[0].value.rstrip("%"))
+            jetson_status.cpu2_freq = int(self.arr.status[2].values[1].value)
+            jetson_status.cpu2_freq_unit = self.arr.status[2].values[2].value
+            jetson_status.cpu2_governor = self.arr.status[2].values[3].value
+            jetson_status.cpu3_load = PERCENT2SHARE * float(self.arr.status[3].values[0].value.rstrip("%"))
+            jetson_status.cpu3_freq = int(self.arr.status[3].values[1].value)
+            jetson_status.cpu3_freq_unit = self.arr.status[3].values[2].value
+            jetson_status.cpu3_governor = self.arr.status[3].values[3].value
+            jetson_status.cpu4_load = PERCENT2SHARE * float(self.arr.status[4].values[0].value.rstrip("%"))
+            jetson_status.cpu4_freq = int(self.arr.status[4].values[1].value)
+            jetson_status.cpu4_freq_unit = self.arr.status[4].values[2].value
+            jetson_status.cpu4_governor = self.arr.status[4].values[3].value
+            jetson_status.cpu5_load = PERCENT2SHARE * float(self.arr.status[5].values[0].value.rstrip("%"))
+            jetson_status.cpu5_freq = int(self.arr.status[5].values[1].value)
+            jetson_status.cpu5_freq_unit = self.arr.status[5].values[2].value
+            jetson_status.cpu5_governor = self.arr.status[5].values[3].value
+            jetson_status.cpu6_load = PERCENT2SHARE * float(self.arr.status[6].values[0].value.rstrip("%"))
+            jetson_status.cpu6_freq = int(self.arr.status[6].values[1].value)
+            jetson_status.cpu6_freq_unit = self.arr.status[6].values[2].value
+            jetson_status.cpu6_governor = self.arr.status[6].values[3].value
+            jetson_status.cpu7_load = PERCENT2SHARE * float(self.arr.status[7].values[0].value.rstrip("%"))
+            jetson_status.cpu7_freq = int(self.arr.status[7].values[1].value)
+            jetson_status.cpu7_freq_unit = self.arr.status[7].values[2].value
+            jetson_status.cpu7_governor = self.arr.status[7].values[3].value
+            jetson_status.cpu8_load = PERCENT2SHARE * float(self.arr.status[8].values[0].value.rstrip("%"))
+            jetson_status.cpu8_freq = int(self.arr.status[8].values[1].value)
+            jetson_status.cpu8_freq_unit = self.arr.status[8].values[2].value
+            jetson_status.cpu8_governor = self.arr.status[8].values[3].value
             # Publish
             self.pub_jetson_status.publish(jetson_status)
+              
 
 def wrapper():
     # Initialization ros node

--- a/ros_jetson_stats/scripts/jetson_stats.py
+++ b/ros_jetson_stats/scripts/jetson_stats.py
@@ -169,39 +169,13 @@ class ROSJtop:
             # GPU temp
             jetson_status.gpu_temp = float(self.arr.status[13].values[4].value.rstrip("C"))
             # CPU info
-            #for i in range(1, 8)
-            jetson_status.cpu1_load = PERCENT2SHARE * float(self.arr.status[1].values[0].value.rstrip("%"))
-            jetson_status.cpu1_freq = int(self.arr.status[1].values[1].value)
-            jetson_status.cpu1_freq_unit = self.arr.status[1].values[2].value
-            jetson_status.cpu1_governor = self.arr.status[1].values[3].value
-            jetson_status.cpu2_load = PERCENT2SHARE * float(self.arr.status[2].values[0].value.rstrip("%"))
-            jetson_status.cpu2_freq = int(self.arr.status[2].values[1].value)
-            jetson_status.cpu2_freq_unit = self.arr.status[2].values[2].value
-            jetson_status.cpu2_governor = self.arr.status[2].values[3].value
-            jetson_status.cpu3_load = PERCENT2SHARE * float(self.arr.status[3].values[0].value.rstrip("%"))
-            jetson_status.cpu3_freq = int(self.arr.status[3].values[1].value)
-            jetson_status.cpu3_freq_unit = self.arr.status[3].values[2].value
-            jetson_status.cpu3_governor = self.arr.status[3].values[3].value
-            jetson_status.cpu4_load = PERCENT2SHARE * float(self.arr.status[4].values[0].value.rstrip("%"))
-            jetson_status.cpu4_freq = int(self.arr.status[4].values[1].value)
-            jetson_status.cpu4_freq_unit = self.arr.status[4].values[2].value
-            jetson_status.cpu4_governor = self.arr.status[4].values[3].value
-            jetson_status.cpu5_load = PERCENT2SHARE * float(self.arr.status[5].values[0].value.rstrip("%"))
-            jetson_status.cpu5_freq = int(self.arr.status[5].values[1].value)
-            jetson_status.cpu5_freq_unit = self.arr.status[5].values[2].value
-            jetson_status.cpu5_governor = self.arr.status[5].values[3].value
-            jetson_status.cpu6_load = PERCENT2SHARE * float(self.arr.status[6].values[0].value.rstrip("%"))
-            jetson_status.cpu6_freq = int(self.arr.status[6].values[1].value)
-            jetson_status.cpu6_freq_unit = self.arr.status[6].values[2].value
-            jetson_status.cpu6_governor = self.arr.status[6].values[3].value
-            jetson_status.cpu7_load = PERCENT2SHARE * float(self.arr.status[7].values[0].value.rstrip("%"))
-            jetson_status.cpu7_freq = int(self.arr.status[7].values[1].value)
-            jetson_status.cpu7_freq_unit = self.arr.status[7].values[2].value
-            jetson_status.cpu7_governor = self.arr.status[7].values[3].value
-            jetson_status.cpu8_load = PERCENT2SHARE * float(self.arr.status[8].values[0].value.rstrip("%"))
-            jetson_status.cpu8_freq = int(self.arr.status[8].values[1].value)
-            jetson_status.cpu8_freq_unit = self.arr.status[8].values[2].value
-            jetson_status.cpu8_governor = self.arr.status[8].values[3].value
+            for i in range(1, 9):
+                if (i == 1 or True):
+                    jetson_status.cpu_load += [PERCENT2SHARE * float(self.arr.status[i].values[0].value.rstrip("%"))]
+                    jetson_status.cpu_freq += [int(self.arr.status[i].values[1].value)]
+                    jetson_status.cpu_freq_unit += [self.arr.status[i].values[2].value]
+                    jetson_status.cpu_governor += [self.arr.status[i].values[3].value]
+
             # Publish
             self.pub_jetson_status.publish(jetson_status)
               

--- a/ros_jetson_stats/scripts/jetson_stats.py
+++ b/ros_jetson_stats/scripts/jetson_stats.py
@@ -165,7 +165,7 @@ class ROSJtop:
             jetson_status.cpu_temp = float(self.arr.status[13].values[6].value.rstrip("C"))
             # GPU info
             jetson_status.gpu_load = PERCENT2SHARE * float(self.arr.status[9].values[0].value.rstrip("%"))
-            jetson_status.gpu_freq = float(self.arr.status[9].values[1].value)
+            jetson_status.gpu_freq = int(self.arr.status[9].values[1].value)
             # GPU temp
             jetson_status.gpu_temp = float(self.arr.status[13].values[4].value.rstrip("C"))
             # Publish


### PR DESCRIPTION
- The frequency was cast from string to float while the frequency in the message definition is an int32
- In noetic this cast seems to cause issues and the message would not be published anymore
- On my Jetson (with ROS noetic and Jetpack 4.5) this fix yields the /gpu_monitor_jetson topic as it used to on melodic